### PR TITLE
feat(universal-router-sdk): support ethrex

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -106,7 +106,7 @@ const CHAIN_CONFIGS: { [key: number]: ChainConfig } = {
   },
   [65536999]: {
     router: '0x4c3155Ec186e19d307B1D7F6af7791a26475047a',
-    weth: '0x36ccfc7163a2c2cdf7a6d6da202eb9c7aa18e4ea',
+    weth: '0x000000000000000000000000000000000000FfFD',
     creationBlock: 1482
   }
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -105,7 +105,7 @@ const CHAIN_CONFIGS: { [key: number]: ChainConfig } = {
     creationBlock: 1116444,
   },
   [65536999]: {
-    router: '0x4c3155Ec186e19d307B1D7F6af7791a26475047a',
+    router: '0x03582E328d69723E0552B8B3AA03B0d6c84dD862',
     weth: '0x000000000000000000000000000000000000FfFD',
     creationBlock: 1482
   }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -104,6 +104,11 @@ const CHAIN_CONFIGS: { [key: number]: ChainConfig } = {
     weth: '0x4300000000000000000000000000000000000004',
     creationBlock: 1116444,
   },
+  [65536999]: {
+    router: '0x9f641622A4528ddd0Ea7F403cf348d24103732BB',
+    weth: '0xeC7ed8038B76DbcB8F78b189EFf9D7C7373A45BE',
+    creationBlock: 1482
+  }
 }
 
 export const UNIVERSAL_ROUTER_ADDRESS = (chainId: number): string => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -105,8 +105,8 @@ const CHAIN_CONFIGS: { [key: number]: ChainConfig } = {
     creationBlock: 1116444,
   },
   [65536999]: {
-    router: '0x9f641622A4528ddd0Ea7F403cf348d24103732BB',
-    weth: '0xeC7ed8038B76DbcB8F78b189EFf9D7C7373A45BE',
+    router: '0x4c3155Ec186e19d307B1D7F6af7791a26475047a',
+    weth: '0x36ccfc7163a2c2cdf7a6d6da202eb9c7aa18e4ea',
     creationBlock: 1482
   }
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -105,8 +105,8 @@ const CHAIN_CONFIGS: { [key: number]: ChainConfig } = {
     creationBlock: 1116444,
   },
   [65536999]: {
-    router: '0x03582E328d69723E0552B8B3AA03B0d6c84dD862',
-    weth: '0x000000000000000000000000000000000000FfFD',
+    router: '0xEE3E6620cb102FcD3b34782E88a4259A192bF1e9',
+    weth: '0xeC7ed8038B76DbcB8F78b189EFf9D7C7373A45BE',
     creationBlock: 1482
   }
 }


### PR DESCRIPTION
**Description**

This PR adds ethrex support with:

weth at: 0xeC7ed8038B76DbcB8F78b189EFf9D7C7373A45BE
router at: 0x9f641622A4528ddd0Ea7F403cf348d24103732BB

The router address should be set as the output of the deployment of https://github.com/lambdaclass/universal-router at ethrex-support branch